### PR TITLE
Patch exports

### DIFF
--- a/src/Data/Generic/Diff.hs
+++ b/src/Data/Generic/Diff.hs
@@ -3,7 +3,6 @@
 {-#  LANGUAGE TypeFamilies  #-}
 {-#  LANGUAGE TypeOperators  #-}
 {-#  LANGUAGE MultiParamTypeClasses  #-}
-{-#  LANGUAGE FunctionalDependencies  #-}
 {-#  LANGUAGE FlexibleInstances  #-}
 {-#  LANGUAGE RankNTypes  #-}
 {-#  LANGUAGE ScopedTypeVariables  #-}

--- a/src/Data/Generic/Diff.hs
+++ b/src/Data/Generic/Diff.hs
@@ -265,9 +265,9 @@ data EditScriptL :: (* -> * -> *) -> * -> * -> * where
 
   End      ::  EditScriptL f Nil                 Nil
 
-type family    Append txs tys :: *
-type instance  Append Nil            tys = tys
-type instance  Append (Cons tx txs)  tys = Cons tx (Append txs tys)
+type family    Append txs tys :: * where
+  Append Nil            tys = tys
+  Append (Cons tx txs)  tys = Cons tx (Append txs tys)
 
 appendList :: IsList f txs -> IsList f tys -> IsList f (Append txs tys)
 appendList IsNil         isys = isys

--- a/src/Data/Generic/Diff.hs
+++ b/src/Data/Generic/Diff.hs
@@ -48,6 +48,13 @@ module Data.Generic.Diff (
     Con(..),
     Nil(..),
     Cons(..),
+    -- ** Exports necessary to reimplement patch
+    List(..),
+    IsList(..),
+    Append,
+    append,
+    split,
+    isList
 ) where
 
 import Data.Type.Equality ( (:~:)(..) )

--- a/src/Data/Generic/Diff.hs
+++ b/src/Data/Generic/Diff.hs
@@ -1,12 +1,9 @@
 {-#  LANGUAGE GADTs  #-}
-{-#  LANGUAGE KindSignatures  #-}
 {-#  LANGUAGE TypeFamilies  #-}
 {-#  LANGUAGE TypeOperators  #-}
 {-#  LANGUAGE MultiParamTypeClasses  #-}
 {-#  LANGUAGE FlexibleInstances  #-}
 {-#  LANGUAGE RankNTypes  #-}
-{-#  LANGUAGE ScopedTypeVariables  #-}
-{-#  LANGUAGE OverlappingInstances  #-} --  Only for the Show
 
 {- |
 


### PR DESCRIPTION
this is intended to resolve issue #2 

Export just enough symbols to make a reimplementation of `patch` outside of `gdiff` painless.