### PR TITLE
Existentials

### DIFF
--- a/src/Data/Generic/Diff.hs
+++ b/src/Data/Generic/Diff.hs
@@ -216,11 +216,13 @@ class (Family f) => Type f t where
 --
 -- Use 'Abstr' for abstract constructors (e.g., for built-in types or types with many
 -- (or infinite) constructors)
+--
+-- Use 'Meta' for abstract constructors whose subtrees are of existential type
+-- (which means exposing 'ts' is forbidden by the type checker)
 data Con :: (* -> * -> *) -> * -> * where
     Concr   :: (List f ts)  =>        f t ts   -> Con f t
     Abstr   :: (List f ts)  => (t ->  f t ts)  -> Con f t
-    --Retro   :: (t -> (Dict (List f) ts, f t ts))  -> Con f t
-    Retro   :: (t -> Con f t)  -> Con f t
+    Meta    ::                 (t -> Con f t)  -> Con f t
 
 class List f ts where
   list :: IsList f ts
@@ -315,8 +317,7 @@ matchConstructor = tryEach constructors
       (forall ts. f t ts -> IsList f ts -> ts -> r) -> r
     tryEach (Concr c  : cs)  x  k  = matchOrRetry c      cs x k
     tryEach (Abstr c  : cs)  x  k  = matchOrRetry (c x)  cs x k
-    --tryEach (Retro c  : cs)  x  k  = case c x of (Dict, c) -> matchOrRetry c cs x k
-    tryEach (Retro c  : cs)  x  k  = tryEach (c x : cs) x k
+    tryEach (Meta  c  : cs)  x  k  = tryEach (c x : cs) x k
     tryEach [] _ _ = error "Incorrect Family or Type instance."
 
     matchOrRetry :: (List f ts, Type f t) => f t ts -> [Con f t] -> t ->

--- a/src/Data/Generic/Diff.hs
+++ b/src/Data/Generic/Diff.hs
@@ -219,6 +219,8 @@ class (Family f) => Type f t where
 data Con :: (* -> * -> *) -> * -> * where
     Concr   :: (List f ts)  =>        f t ts   -> Con f t
     Abstr   :: (List f ts)  => (t ->  f t ts)  -> Con f t
+    --Retro   :: (t -> (Dict (List f) ts, f t ts))  -> Con f t
+    Retro   :: (t -> Con f t)  -> Con f t
 
 class List f ts where
   list :: IsList f ts
@@ -313,6 +315,8 @@ matchConstructor = tryEach constructors
       (forall ts. f t ts -> IsList f ts -> ts -> r) -> r
     tryEach (Concr c  : cs)  x  k  = matchOrRetry c      cs x k
     tryEach (Abstr c  : cs)  x  k  = matchOrRetry (c x)  cs x k
+    --tryEach (Retro c  : cs)  x  k  = case c x of (Dict, c) -> matchOrRetry c cs x k
+    tryEach (Retro c  : cs)  x  k  = tryEach (c x : cs) x k
     tryEach [] _ _ = error "Incorrect Family or Type instance."
 
     matchOrRetry :: (List f ts, Type f t) => f t ts -> [Con f t] -> t ->


### PR DESCRIPTION
This pull request establishes a third way of describing node constructors for `gdiff`. The new `Meta` constructor subsumes the functionality of `Abstr` but is a bit less efficient. The usage recipe is
``` haskell
{-#  LANGUAGE FlexibleContexts, ScopedTypeVariables  #-}

data Hidden = forall t . Type Fam t => Hide t

data Fam ft ts where
  Hidden' :: List Fam ts => Fam t ts -> Fam Hidden ts
  -- ...

instance Family Fam where

instance Type Fam Hidden where
  constructors = [Meta $ \(Hide (a :: t)) -> head $ [ Concr (Hidden' con)
                                                    | Concr con :: Con Fam t <- constructors
                                                    , Just _ <- [fields con a]
                                                    ]
                 ]
```
With `Abstr` its is impossible to define a function of type `Hidden -> Fam Hidden (Cons a Nil)` since it would expose a (skolem constant) unknown existential type. However it is entirely possible to write a function of type `Hidden -> Con Fam Hidden` as requested by the new `Meta` way.