### PR TITLE
Give `Cons` and `CCons` the same precedence as (:)

### DIFF
--- a/src/Data/Generic/Diff.hs
+++ b/src/Data/Generic/Diff.hs
@@ -92,6 +92,9 @@ data Nil        = CNil
 -- your 'Family' instance.
 data Cons x xs  = CCons x xs
 
+infixr 5 `Cons`
+infixr 5 `CCons`
+
 {- |
 
 To use 'diff' and 'patch' on your datatypes, you must create an instance of


### PR DESCRIPTION
I believe this is a pretty sane default.
